### PR TITLE
Fixed next event time calculations.

### DIFF
--- a/src/framework/mil.sstaf.core/src/integrationTest/java/mil/sstaf/core/integration/AppSupportTest.java
+++ b/src/framework/mil.sstaf.core/src/integrationTest/java/mil/sstaf/core/integration/AppSupportTest.java
@@ -46,7 +46,7 @@ public class AppSupportTest {
             AppAdapter helper = AppSupport.createAdapter(config);
             ResourceManager resourceManager = helper.getResourceManager();
             File py = resourceManager.getResourceFiles().get("mil/sstaftest/simplemock/upper.py");
-            helper.setArgs(List.of("python3", py.getAbsolutePath()));
+            helper.setArgs(List.of("python", py.getAbsolutePath()));
             exerciseApplication(helper);
         });
     }
@@ -64,7 +64,7 @@ public class AppSupportTest {
             AppAdapter helper = AppSupport.createAdapter(config);
             ResourceManager resourceManager = helper.getResourceManager();
             File py = resourceManager.getResourceFiles().get("mil/sstaftest/simplemock/upper.py");
-            helper.setArgs(List.of("python3", py.getAbsolutePath()));
+            helper.setArgs(List.of("python", py.getAbsolutePath()));
 
             exerciseApplication(helper);
 
@@ -109,7 +109,7 @@ public class AppSupportTest {
         File py = resourceManager.getResourceFiles().get("mil/sstaftest/simplemock/args.py");
 
         final String bilbo = "Bilbo";
-        helper.setArgs(List.of("python3", py.getAbsolutePath(), bilbo));
+        helper.setArgs(List.of("python", py.getAbsolutePath(), bilbo));
 
         AppSession session = helper.activate();
         String arg0 = session.invoke("0");
@@ -119,7 +119,7 @@ public class AppSupportTest {
         Assertions.assertEquals(bilbo, arg1);
 
         final String frodo = "Frodo";
-        helper.setArgs(List.of("python3", py.getAbsolutePath(), frodo));
+        helper.setArgs(List.of("python", py.getAbsolutePath(), frodo));
 
         session = helper.activate();
         arg0 = session.invoke("0");
@@ -129,7 +129,7 @@ public class AppSupportTest {
         Assertions.assertEquals(frodo, arg1);
 
         final String sam = "Sam";
-        session = helper.activate(List.of("python3", py.getAbsolutePath(), sam));
+        session = helper.activate(List.of("python", py.getAbsolutePath(), sam));
         arg0 = session.invoke("0");
         Assertions.assertEquals(py.getAbsolutePath(), arg0);
 

--- a/src/framework/mil.sstaf.session/src/main/java/mil/sstaf/session/control/Session.java
+++ b/src/framework/mil.sstaf.session/src/main/java/mil/sstaf/session/control/Session.java
@@ -145,7 +145,7 @@ public final class Session implements AutoCloseable {
      * @return an empty {@code SessionTickResult}
      */
     public SessionTickResult getEmptyTickResult() {
-        return SessionTickResult.builder().nextEventTime_ms(currentTime_ms).build();
+        return SessionTickResult.builder().nextEventTime_ms(entityController.getNextEventTime_ms()).build();
     }
 
 

--- a/src/framework/mil.sstaf.session/src/test/java/mil/sstaf/session/control/EntityControllerTest.java
+++ b/src/framework/mil.sstaf.session/src/test/java/mil/sstaf/session/control/EntityControllerTest.java
@@ -88,6 +88,24 @@ class EntityControllerTest {
         }
 
         @Test
+        @DisplayName("Confirm that next event time is calculated correctly")
+        void testUpcomingEvent() {
+            Collection<EntityHandle> allPaths = entityController.getSimulationEntityHandles();
+            Event event = Event.builder()
+                    .recipientPath(allPaths.iterator().next().getPath())
+                    .content(StringContent.builder().value("This is a test").build())
+                    .eventTime_ms(10000)
+                    .build();
+            entityController.submitEvent(event);
+            assertEquals(1, entityController.getSessionProxyQueueDepth(), "Queue depth before tick");
+            assertEquals(10000, entityController.getNextEventTime_ms());
+            SessionTickResult result = entityController.tick(5000);
+            assertEquals(10000, result.getNextEventTime_ms());
+            result = entityController.tick(10000);
+            assertEquals(Long.MAX_VALUE, result.getNextEventTime_ms());
+        }
+
+        @Test
         @DisplayName("Confirm that getSimulationEntityHandles() works as expected")
         void getAllEntityHandles() {
             Collection<EntityHandle> allPaths = entityController.getSimulationEntityHandles();


### PR DESCRIPTION
Events before current tick are ignored, defaults to max (not zero).  Analyzer empty tick result now includes next event time.