### PR TITLE
Fixed 9-equipmenthandler-does-not-register-messages-handled

### DIFF
--- a/src/features/equipment/mil.devcom_dac.equipment.handler/build.gradle
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/build.gradle
@@ -5,4 +5,24 @@ dependencies {
 }
 
 
+testing {
+    suites {
+        integrationTest {
+            dependencies {
+                implementation project(':framework:mil.sstaf.core')
+                implementation project(':testFeatures:integration:mil.sstaftest.simplemock')
+                implementation project(':testFeatures:integration:mil.sstaftest.jamesbond')
+                implementation project(':testFeatures:integration:mil.sstaftest.alpha')
+                implementation project(':testFeatures:integration:mil.sstaftest.bravo')
+                implementation project(':testFeatures:integration:mil.sstaftest.charlie')
+                implementation project(':testFeatures:integration:mil.sstaftest.delta')
+                implementation project(':testFeatures:integration:mil.sstaftest.echo')
+                implementation project(':testFeatures:support:mil.sstaftest.mocks.pinky')
 
+                runtimeOnly project(':testFeatures:support:mil.sstaftest.mocks.handler1')
+                runtimeOnly project(':testFeatures:support:mil.sstaftest.mocks.agent1')
+                runtimeOnly project(':testFeatures:support:mil.sstaftest.mocks.pinky')
+            }
+        }
+    }
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/main/java/mil/devcom_dac/equipment/handler/EquipmentHandler.java
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/main/java/mil/devcom_dac/equipment/handler/EquipmentHandler.java
@@ -58,6 +58,9 @@ public class EquipmentHandler extends BaseHandler implements EquipmentManagement
     @Override
     public void init() {
         super.init();
+        if (currentGun.getMagazine() == null) {
+            kit.reload(currentGun);
+        }
     }
 
     /**
@@ -150,6 +153,9 @@ public class EquipmentHandler extends BaseHandler implements EquipmentManagement
         var builder = Inventory.builder();
         if (currentGun == null) {
             builder.currentGun("None");
+            builder.roundsInCurrentGun(0);
+        } else if (currentGun.getMagazine() == null){
+            builder.currentGun(currentGun.getName());
             builder.roundsInCurrentGun(0);
         } else {
             builder.currentGun(currentGun.getName());

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/java/mil/devcom_dac/equipment/handler/EquipmentHandlerTest.java
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/java/mil/devcom_dac/equipment/handler/EquipmentHandlerTest.java
@@ -1,0 +1,75 @@
+package mil.devcom_dac.equipment.handler;
+
+import mil.devcom_dac.equipment.api.EquipmentConfiguration;
+import mil.devcom_dac.equipment.api.EquipmentManagement;
+import mil.devcom_dac.equipment.messages.GetInventory;
+import mil.sstaf.core.entity.Address;
+import mil.sstaf.core.entity.EntityHandle;
+import mil.sstaf.core.features.Loaders;
+import mil.sstaf.core.json.JsonLoader;
+import mil.sstaf.core.util.Injector;
+import org.junit.jupiter.api.*;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EquipmentHandlerTest {
+    public static Path basepath = Path.of("src", "test", "resources");
+    static EquipmentConfiguration configuration;
+    EquipmentManagement equipmentManagement;
+
+    @BeforeAll
+    static void beginning() {
+        configuration = new JsonLoader().load(Path.of(basepath.toString(), "TestConfig.json"),
+                EquipmentConfiguration.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        System.out.println(new File(".").getName());
+        try {
+            System.setProperty("sstaf.preloadFeatureClasses", "true");
+            Loaders.preloadFeatureClasses("mil.devcom_dac.equipment.handler.EquipmentHandler");
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            fail();
+        }
+
+        Optional<EquipmentManagement> optAgent = Loaders.load(EquipmentManagement.class, "Kit Manager", 0, 0);
+        if (optAgent.isPresent()) {
+            equipmentManagement = optAgent.get();
+            equipmentManagement.configure(configuration);
+        } else {
+            Assertions.fail();
+        }
+
+        EntityHandle owner = EntityHandle.makeDummyHandle();
+        Injector.inject(equipmentManagement, owner);
+        equipmentManagement.init();
+    }
+
+    @Nested
+    @DisplayName("Test the happy path scenarios")
+    class HappyTests {
+        @Test
+        @DisplayName("Confirm that the EquipmentHandler can be loaded successfully")
+        public void test1() {
+            assertNotNull(equipmentManagement);
+            assertNotNull(equipmentManagement.getGuns().get("M16A1"));
+        }
+
+        @Test
+        @DisplayName("Confirm that GetInventory message works")
+        public void test2() {
+            assertNotNull(equipmentManagement);
+            GetInventory msg = GetInventory.builder().build();
+            var x = equipmentManagement.process(msg, 1000, 1000,
+                    Address.NOWHERE, 1 , Address.NOWHERE);
+            assertNotNull(x);
+            assertEquals(1, x.messages.size());
+        }
+    }
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/FannyPack.json
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/FannyPack.json
@@ -1,0 +1,5 @@
+{
+  "class" : "mil.devcom_dac.equipment.api.Pack",
+  "name": "Fanny Pack",
+  "mass_kg": 1.5
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/M16A1.json
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/M16A1.json
@@ -1,0 +1,6 @@
+{
+  "class" : "mil.devcom_dac.equipment.api.Gun",
+  "name": "M16A1",
+  "magazineType": "5.56mm STANAG",
+  "emptyMass_kg": 5.5
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/STANAGMagazine.json
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/STANAGMagazine.json
@@ -1,0 +1,9 @@
+{
+  "class" : "mil.devcom_dac.equipment.api.Magazine",
+  "name": "5.56mm STANAG 30rd",
+  "magazineType": "5.56mm STANAG",
+  "capacity": 30,
+  "currentLoad" : 30,
+  "perRoundMass_kg": 0.01231,
+  "emptyMass_kg": 0.1207
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/TestConfig.json
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/TestConfig.json
@@ -1,0 +1,4 @@
+{
+  "class" : "mil.devcom_dac.equipment.api.EquipmentConfiguration",
+  "kit" : "TestKit.json"
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/TestKit.json
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/TestKit.json
@@ -1,0 +1,15 @@
+{
+  "class" : "mil.devcom_dac.equipment.api.Kit",
+  "guns": [
+    "M16A1.json"
+  ],
+  "magazines": [
+    "STANAGMagazine.json",
+    "STANAGMagazine.json",
+    "STANAGMagazine.json",
+    "STANAGMagazine.json"
+  ],
+  "packs": [
+    "FannyPack.json"
+  ]
+}

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/log4j2-test.xml
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/test/resources/log4j2-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022
+  ~ United States Government as represented by the U.S. Army DEVCOM Analysis Center.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Also
- addressed the NPE that was due to the gun not containing an initial magazine. The solution was to automatically reload in init();
- revised buildInventory() to handle null magazines.