### PR TITLE
Fixed 22-gradle-warnings-on-unit-tests

### DIFF
--- a/src/framework/mil.sstaf.core/build.gradle
+++ b/src/framework/mil.sstaf.core/build.gradle
@@ -7,14 +7,6 @@ test.dependsOn(':testModules:mil.sstaftest.barney:build')
 test.dependsOn(':testModules:mil.sstaftest.wilma:build')
 test.dependsOn(':testModules:mil.sstaftest.betty:build')
 
-integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.jamesbond:copyJar')
-integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.alpha:copyJar')
-integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.bravo:copyJar')
-integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.charlie:copyJar')
-integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.delta:copyJar')
-integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.echo:copyJar')
-integrationTest.dependsOn(':testFeatures:support:mil.sstaftest.mocks.pinky:copyJar')
-
 testing {
     suites {
         integrationTest {


### PR DESCRIPTION
Deleted "integrationTest.dependsOn" statements from build.gradle. These generated warnings under Gradle 7.5.1. System still builds without issue using gradlew.