### PR TITLE
38 record shoot metrics

### DIFF
--- a/src/features/equipment/mil.devcom_dac.equipment.handler/build.gradle
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation project(':features:equipment:mil.devcom_dac.equipment.messages')
     implementation project(':features:equipment:mil.devcom_dac.equipment.api')
+    implementation project(path: ':features:support:mil.sstaf.blackboard.api')
     testImplementation project(path: ':features:ansurHandler:mil.devcom_sc.ansur.messages')
 }
 

--- a/src/features/equipment/mil.devcom_dac.equipment.handler/src/main/java/module-info.java
+++ b/src/features/equipment/mil.devcom_dac.equipment.handler/src/main/java/module-info.java
@@ -28,8 +28,11 @@ module mil.devcom_dac.equipment.handler {
     requires mil.devcom_dac.equipment.api;
 
     requires org.slf4j;
+    requires mil.sstaf.blackboard.api;
 
     provides EquipmentManagement with EquipmentHandler;
     provides SoldierKit with EquipmentHandler;
     provides Feature with EquipmentHandler;
+
+    opens mil.devcom_dac.equipment.handler to mil.sstaf.core;
 }

--- a/src/features/equipment/mil.devcom_dac.equipment.messages/src/main/java/mil/devcom_dac/equipment/messages/GunMetric.java
+++ b/src/features/equipment/mil.devcom_dac.equipment.messages/src/main/java/mil/devcom_dac/equipment/messages/GunMetric.java
@@ -1,0 +1,21 @@
+package mil.devcom_dac.equipment.messages;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import mil.sstaf.core.state.LabeledState;
+import mil.sstaf.core.state.StateProperty;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@Jacksonized
+public class GunMetric extends LabeledState {
+    private final int numberShot;
+
+    @StateProperty(headerLabel = "Shots Fired")
+    public int getNumberShot() {
+        return numberShot;
+    }
+}


### PR DESCRIPTION
Added Shoot Metric to Equipment Manager (v0.2.0).  This generates cumulative shots taken for a soldier for all guns.