### PR TITLE
41 update comfasterxmljacksoncorejackson databind to version 21341

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -15,9 +15,9 @@ repositories {
 
 dependencies {
     implementation 'org.ow2.asm:asm:9.2'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
     // Use JUnit test framework for unit tests
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.8.1'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
     // Apply the Java Gradle plugin development plugin to add support for developing Gradle plugins
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '1.1.0'
+    id 'com.gradle.plugin-publish' version '1.2.0'
 }
 
 repositories {
@@ -14,13 +14,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.ow2.asm:asm:9.2'
+    implementation 'org.ow2.asm:asm:9.5'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
     // Use JUnit test framework for unit tests
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.10.0'
 }
 
 group 'sstaf'

--- a/src/applications/analyzer/build.gradle
+++ b/src/applications/analyzer/build.gradle
@@ -15,14 +15,14 @@ dependencies {
     implementation project(':framework:mil.sstaf.session')
     implementation project(':framework:mil.sstaf.analyzer')
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
-    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    implementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     runtimeOnly group: 'org.apache.commons', name: 'commons-csv', version: '1.8'
-    runtimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.32'
-    runtimeOnly group: 'net.java.dev.jna', name: 'jna', version: '5.4.0'
+    runtimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.7'
+    runtimeOnly group: 'net.java.dev.jna', name: 'jna', version: '5.13.0'
     runtimeOnly project(':features:ansurHandler:mil.devcom_sc.ansur.api')
     runtimeOnly project(':features:ansurHandler:mil.devcom_sc.ansur.messages')
     runtimeOnly project(':features:ansurHandler:mil.devcom_sc.ansur.handler')
@@ -53,9 +53,9 @@ sstaf {
         exports('org.apache.commons.math3.analysis')
     }
 
-    module('jopt-simple-4.6.jar', 'jopt.simple', '4.6')
-    module('jmh-generator-annprocess-1.21.jar', 'jmh.generator.annprocess', '1.21')
-    module('jmh-core-1.21.jar', 'jmh.core', '1.21') {
+    module('jopt-simple-5.0.4.jar', 'jopt.simple', '5.0.4')
+    module('jmh-generator-annprocess-1.36.jar', 'jmh.generator.annprocess', '1.36')
+    module('jmh-core-1.36.jar', 'jmh.core', '1.36') {
         exports('org.openjdk.jmh.annotations')
         exports('org.openjdk.jmh')
     }
@@ -93,8 +93,8 @@ testing {
                 implementation project(':framework:mil.sstaf.core')
                 implementation project(':framework:mil.sstaf.session')
                 implementation project(':framework:mil.sstaf.analyzer')
-				implementation 'org.slf4j:slf4j-api:2.0.6'
-				implementation 'org.slf4j:slf4j-simple:2.0.6'
+				implementation 'org.slf4j:slf4j-api:2.0.7'
+				implementation 'org.slf4j:slf4j-simple:2.0.7'
                 implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
                 implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
                 implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'

--- a/src/applications/analyzer/build.gradle
+++ b/src/applications/analyzer/build.gradle
@@ -16,9 +16,9 @@ dependencies {
     implementation project(':framework:mil.sstaf.analyzer')
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
     implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     runtimeOnly group: 'org.apache.commons', name: 'commons-csv', version: '1.8'
     runtimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.32'
@@ -95,9 +95,9 @@ testing {
                 implementation project(':framework:mil.sstaf.analyzer')
 				implementation 'org.slf4j:slf4j-api:2.0.6'
 				implementation 'org.slf4j:slf4j-simple:2.0.6'
-                implementation 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-                implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+                implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+                implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
                 implementation project(':features:ansurHandler:mil.devcom_sc.ansur.messages')
                 runtimeOnly project(':features:ansurHandler:mil.devcom_sc.ansur.api')
                 runtimeOnly project(':features:ansurHandler:mil.devcom_sc.ansur.handler')

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -10,9 +10,9 @@ buildscript {
     dependencies {
         classpath 'org.ow2.asm:asm:9.2'
         classpath 'org.projectlombok:lombok:1.18.22'
-        classpath 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-        classpath 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-        classpath 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+        classpath 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+        classpath 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+        classpath 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
     }
 }
 
@@ -119,9 +119,9 @@ configure(modules) {
 		implementation 'org.slf4j:slf4j-simple:2.0.6'
         implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
 
-        implementation 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+        implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
 
         implementation 'org.projectlombok:lombok:1.18.22'
 
@@ -162,9 +162,9 @@ configure(modules) {
 					implementation 'org.slf4j:slf4j-api:2.0.6'
 					implementation 'org.slf4j:slf4j-simple:2.0.6'
 					implementation 'org.apache.commons:commons-math3:3.6.1'
-                    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.1'
-                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+                    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+                    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
                     implementation 'org.junit.jupiter:junit-jupiter:5.8.2'
                     implementation 'org.apiguardian:apiguardian-api:1.1.2'
                     runtimeOnly 'org.junit.jupiter:junit-jupiter:5.8.2'

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.ow2.asm:asm:9.2'
-        classpath 'org.projectlombok:lombok:1.18.22'
+        classpath 'org.ow2.asm:asm:9.5'
+        classpath 'org.projectlombok:lombok:1.18.28'
         classpath 'com.fasterxml.jackson.core:jackson-core:2.15.2'
         classpath 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
         classpath 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
@@ -20,7 +20,7 @@ plugins {
     id 'java-library'
     id 'jvm-test-suite'
     id 'maven-publish'
-    id 'io.freefair.lombok' version '6.4.1'
+    id 'io.freefair.lombok' version '8.1.0'
     id 'sstaf' version '1.0'
 	id 'java'
 }
@@ -37,7 +37,7 @@ java {
 
 /*
  * Many libraries have yet to be upgrades as fully-compliant modules. This block defines modules for specific
- * legacy libraries. It works with the plugin in the buildSrc diqrectory,
+ * legacy libraries. It works with the plugin in the buildSrc directory,
  */
 Set<Project> modules = subprojects.findAll { project ->
     project.path.contains('mil.') || project.path.contains('edu')
@@ -93,9 +93,9 @@ configure(modules) {
             exports('org.apache.commons.math3.analysis')
         }
 
-        module('jopt-simple-4.6.jar', 'jopt.simple', '4.6')
-        module('jmh-generator-annprocess-1.21.jar', 'jmh.generator.annprocess', '1.21')
-        module('jmh-core-1.21.jar', 'jmh.core', '1.21') {
+        module('jopt-simple-5.0.4.jar', 'jopt.simple', '5.0.4')
+        module('jmh-generator-annprocess-1.36.jar', 'jmh.generator.annprocess', '1.36')
+        module('jmh-core-1.36.jar', 'jmh.core', '1.36') {
             exports('org.openjdk.jmh.annotations')
             exports('org.openjdk.jmh')
         }
@@ -115,21 +115,21 @@ configure(modules) {
 
     dependencies {
 
-		implementation 'org.slf4j:slf4j-api:2.0.6'
-		implementation 'org.slf4j:slf4j-simple:2.0.6'
+		implementation 'org.slf4j:slf4j-api:2.0.7'
+		implementation 'org.slf4j:slf4j-simple:2.0.7'
         implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
 
         implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
         implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
         implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
 
-        implementation 'org.projectlombok:lombok:1.18.22'
+        implementation 'org.projectlombok:lombok:1.18.28'
 
-        testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 		testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.9.0'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.10.0'
         testRuntimeOnly 'org.apiguardian:apiguardian-api:1.1.2'
-        testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.32'
+        testRuntimeOnly group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.7'
     }
 
     publishing {
@@ -159,18 +159,18 @@ configure(modules) {
             integrationTest(JvmTestSuite) {
                 dependencies {
                     implementation project()
-					implementation 'org.slf4j:slf4j-api:2.0.6'
-					implementation 'org.slf4j:slf4j-simple:2.0.6'
+					implementation 'org.slf4j:slf4j-api:2.0.7'
+					implementation 'org.slf4j:slf4j-simple:2.0.7'
 					implementation 'org.apache.commons:commons-math3:3.6.1'
                     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
                     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
                     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
-                    implementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+                    implementation 'org.junit.jupiter:junit-jupiter:5.10.0'
                     implementation 'org.apiguardian:apiguardian-api:1.1.2'
-                    runtimeOnly 'org.junit.jupiter:junit-jupiter:5.8.2'
+                    runtimeOnly 'org.junit.jupiter:junit-jupiter:5.10.0'
                     runtimeOnly 'org.apiguardian:apiguardian-api:1.1.2'
-					runtimeOnly 'org.slf4j:slf4j-api:2.0.6'
-					runtimeOnly 'org.slf4j:slf4j-simple:2.0.6'
+					runtimeOnly 'org.slf4j:slf4j-api:2.0.7'
+					runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
                 }
 
                 targets {

--- a/src/features/ansurHandler/mil.devcom_sc.ansur.handler/build.gradle
+++ b/src/features/ansurHandler/mil.devcom_sc.ansur.handler/build.gradle
@@ -18,3 +18,4 @@ task copyResources(type: Copy) {
 processResources.dependsOn copyResources
 
 
+

--- a/src/features/ansurHandler/mil.devcom_sc.ansur.messages/build.gradle
+++ b/src/features/ansurHandler/mil.devcom_sc.ansur.messages/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation project(':framework:mil.sstaf.core')
-    implementation 'org.projectlombok:lombok:1.18.20'
+    implementation 'org.projectlombok:lombok:1.18.28'
 
     testRuntimeOnly project(":features:support:mil.sstaf.blackboard.inmem")
 }

--- a/src/features/equipment/mil.devcom_dac.equipment.messages/build.gradle
+++ b/src/features/equipment/mil.devcom_dac.equipment.messages/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation project(':framework:mil.sstaf.core')
-    implementation 'org.projectlombok:lombok:1.18.20'
+    implementation 'org.projectlombok:lombok:1.18.28'
 
 }
 

--- a/src/features/simplePhysiologyAgent/mil.sstaf.physiology.agent/build.gradle
+++ b/src/features/simplePhysiologyAgent/mil.sstaf.physiology.agent/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation project(':features:support:mil.sstaf.blackboard.api');
 
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation project(':features:ansurHandler:mil.devcom_sc.ansur.messages')
     implementation project(':features:ansurHandler:mil.devcom_sc.ansur.api')
     implementation project(':features:simplePhysiologyAgent:mil.sstaf.physiology.api')

--- a/src/features/simplePhysiologyAgent/mil.sstaf.physiology.api/build.gradle
+++ b/src/features/simplePhysiologyAgent/mil.sstaf.physiology.api/build.gradle
@@ -4,7 +4,7 @@ plugins {
 ext.moduleName = 'mil.sstaf.physiology.api'
 
 dependencies {
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation project(':framework:mil.sstaf.core')
     implementation project(':features:support:mil.sstaf.blackboard.api')
     implementation project(':features:ansurHandler:mil.devcom_sc.ansur.messages')

--- a/src/features/support/mil.sstaf.blackboard.api/build.gradle
+++ b/src/features/support/mil.sstaf.blackboard.api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }
 
 

--- a/src/features/support/mil.sstaf.blackboard.inmem/build.gradle
+++ b/src/features/support/mil.sstaf.blackboard.inmem/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':features:support:mil.sstaf.blackboard.api')
     implementation project(':framework:mil.sstaf.core')
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     testImplementation project(':verification:mil.sstaftest.util')
 

--- a/src/features/support/mil.sstaf.telemetry/build.gradle
+++ b/src/features/support/mil.sstaf.telemetry/build.gradle
@@ -6,7 +6,7 @@ ext.moduleName = 'mil.sstaf.telemetry'
 dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation project(':features:support:mil.sstaf.blackboard.api')
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     testImplementation project(':verification:mil.sstaftest.util')
     testRuntimeOnly project(':features:support:mil.sstaf.blackboard.inmem')

--- a/src/framework/mil.sstaf.analyzer/build.gradle
+++ b/src/framework/mil.sstaf.analyzer/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation project(':framework:mil.sstaf.session')
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
 }
 

--- a/src/framework/mil.sstaf.core/build.gradle
+++ b/src/framework/mil.sstaf.core/build.gradle
@@ -6,6 +6,8 @@ test.dependsOn(':testModules:mil.sstaftest.fred:build')
 test.dependsOn(':testModules:mil.sstaftest.barney:build')
 test.dependsOn(':testModules:mil.sstaftest.wilma:build')
 test.dependsOn(':testModules:mil.sstaftest.betty:build')
+integrationTest.dependsOn(':testFeatures:support:mil.sstaftest.mocks.pinky:build')
+integrationTest.dependsOn(':testFeatures:integration:mil.sstaftest.jamesbond:build')
 
 testing {
     suites {

--- a/src/framework/mil.sstaf.session/build.gradle
+++ b/src/framework/mil.sstaf.session/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation project(':features:support:mil.sstaf.blackboard.api')
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }

--- a/src/testFeatures/human/mil.sstaftest.anthropometry.api/build.gradle
+++ b/src/testFeatures/human/mil.sstaftest.anthropometry.api/build.gradle
@@ -5,7 +5,7 @@ ext.moduleName = 'mil.sstaftest.anthropometry.api'
 
 dependencies {
     implementation project(':framework:mil.sstaf.core')
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
 }
 

--- a/src/testFeatures/human/mil.sstaftest.anthropometry.simple/build.gradle
+++ b/src/testFeatures/human/mil.sstaftest.anthropometry.simple/build.gradle
@@ -5,7 +5,7 @@ ext.moduleName = 'mil.sstaftest.anthropometry.simple'
 
 dependencies {
     implementation project(':framework:mil.sstaf.core')
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation project(':testFeatures:human:mil.sstaftest.anthropometry.api')
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
 

--- a/src/testFeatures/integration/mil.sstaftest.alpha/build.gradle
+++ b/src/testFeatures/integration/mil.sstaftest.alpha/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(':framework:mil.sstaf.core')
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }
 
 task copyJar(type: Copy) {

--- a/src/verification/mil.sstaftest.util/build.gradle
+++ b/src/verification/mil.sstaftest.util/build.gradle
@@ -43,8 +43,8 @@ jar {
 
 dependencies {
     implementation project(':framework:mil.sstaf.core')
-    implementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }
 
 


### PR DESCRIPTION
Lots of dependency updates:

com.fasterxml.jackson.core 2.13.1 to 2.15.2
org.ow2.asm:asm 9.2 to 9.5
jopt-simple-4.6 to 5.0.4
jmh-generator-annprocess 1.21 to 1.36
jmh.core 1.21 to 1.36
org.projectlombok:lombok 1.18.22 to 1.18.28
io.freefair.lombok 6.4.1 to 8.1.0
slf4j-api 2.0.6 to 2.0.7 (some updated from 1.7.32)
slf4j-simple 2.0.6 to 2.0.7 (some updated from 1.7.32)
junit-jupiter 5.8.1 to 5.10.0 (some updated from 5.7.2)
com.gradle.plugin-publish 1.1.0 to 1.2.0
jna 5.4.0 to 5.13.0

SKIPPED:
commons.csv 1.8 to 1.10.0  (See Issue #43)

Also added dependencies for framework tests.